### PR TITLE
Update README.md

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -35,6 +35,22 @@ cargo add surrealdb
 
 **IMPORTANT**: The client supports SurrealDB `v1.0.0-beta.8+20221030.c12a1cc` or later. So please make sure you have that or a newer version of the server before proceeding. For now, that means a recent nightly version.
 
+To use the local engine you will need to add the local engine feature to Cargo.toml eg to use the latest from github:
+
+    surrealdb = { git = "https://github.com/surrealdb/surrealdb", features = ["kv-rocksdb"] }
+	
+NB: currently you cannot use cargo to add the feature:
+
+    cargo add surrealdb -F kv-rocksdb
+        Updating git repository `https://github.com/surrealdb/surrealdb`
+          Adding surrealdb (git) to dependencies.
+    error: unrecognized features for crate surrealdb: default, kv-rocksdb
+    no features available for crate surrealdb
+
+You will also need to ensure that your Operating System has "clang" installed. eg on Ubuntu:
+
+    sudo apt-get install clang
+	
 <h2><img height="20" src="https://github.com/surrealdb/surrealdb/blob/main/img/features.svg?raw=true">&nbsp;&nbsp;Quick look</h2>
 
 This library enables simple and advanced querying of an embedded or remote database from server-side or client-side (via Wasm) code. By default, all remote connections to SurrealDB are made over WebSockets, and automatically reconnect when the connection is terminated. Connections are automatically closed when they get dropped.


### PR DESCRIPTION
Added to installation the local engine feature, noting that "cargo add surrealDB -F -kv-rocksdb" does not work at the moment.

Also noted that clang must be installed for the local engine.

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I had to work this out as I couldn't find it documented

## What does this change do?

Adds to the rust library installation

## What is your testing strategy?

n/a

## Is this related to any issues?

n/a

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
